### PR TITLE
limit zoom to 5 to avoid blurry images

### DIFF
--- a/components/Map/NewMap.tsx
+++ b/components/Map/NewMap.tsx
@@ -25,7 +25,7 @@ const NewMap = () => {
           backgroundColor: '#AEDBC4',
         }}
       >
-        <ReactNativeZoomableView maxZoom={10}>
+        <ReactNativeZoomableView maxZoom={5}>
           <Image
             style={{ width: '100%', height: '100%', resizeMode: 'contain' }}
             source={layer === 'normal' ? Grondplan : GrondPlanGrootSpel}


### PR DESCRIPTION
Concerning issue #236:

I've fallen off the deep end here. I tried 
- different image-zoom modules
- exporting images at several power-2 resolutions
- switching to svg

The main take home message is that we might need to implement our own zoomable image wrapper, since none of the existing ones are capable of zooming in properly. Also svg will not work out-of-the-box (cfr: https://stackoverflow.com/a/61141177)

So my non-solution is limiting the zoom to 5x which seems to be the best trade-off. @thomasdewulf you're call to close this issue (#236)